### PR TITLE
Show vertical scrollbar only when required

### DIFF
--- a/static/3rd/dokuwiki/basic.css
+++ b/static/3rd/dokuwiki/basic.css
@@ -10,7 +10,7 @@
 
 html {
     overflow-x: auto;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 html, body {
     background-color: __background__;


### PR DESCRIPTION
By default the template always shows vertical scrollbar even if not required.
This micro commit fixes that.
