### PR TITLE
change messages and translations

### DIFF
--- a/lang/ca/lang.php
+++ b/lang/ca/lang.php
@@ -69,7 +69,7 @@ $lang["vector_exportbxdef_downloadpdf"] = "Baixa en format PDF";
 //default toolbox
 $lang["vector_toolbxdef_whatlinkshere"] = "Què hi enllaça";
 $lang["vector_toolbxdef_upload"] = "Gestor de fitxers";
-$lang["vector_toolbxdef_siteindex"] = "Índex del lloc";
+$lang["vector_toolbxdef_siteindex"] = "Mapa del lloc";
 $lang["vector_toolboxdef_permanent"] = "Enllaç permanent";
 $lang["vector_toolboxdef_cite"] = "Cita aquesta pàgina";
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -49,7 +49,7 @@ $lang["vector_translations"] = "Languages";
 
 //headlines for the different bars and boxes
 $lang["vector_navigation"] = "Navigation";
-$lang["vector_toolbox"] = "Toolbox";
+$lang["vector_toolbox"] = "Tools";
 $lang["vector_exportbox"] = "Print/export";
 $lang["vector_qrcodebox"] = "QR Code";
 $lang["vector_inotherlanguages"] = "Languages";
@@ -69,7 +69,7 @@ $lang["vector_exportbxdef_downloadpdf"] = "Download as PDF";
 //default toolbox
 $lang["vector_toolbxdef_whatlinkshere"] = "What links here";
 $lang["vector_toolbxdef_upload"] = "Upload file";
-$lang["vector_toolbxdef_siteindex"] = "Site index";
+$lang["vector_toolbxdef_siteindex"] = "Sitemap";
 $lang["vector_toolboxdef_permanent"] = "Permanent link";
 $lang["vector_toolboxdef_cite"] = "Cite this page";
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -56,9 +56,9 @@ $lang["vector_exportbox_default"]  = "If yes, use default 'print/export' box?";
 $lang["vector_exportbox_location"] = "If not default, use following wiki page as 'print/export' box location:";
 
 //toolbox
-$lang["vector_toolbox"]          = "Show toolbox?";
-$lang["vector_toolbox_default"]  = "If yes, use default toolbox?";
-$lang["vector_toolbox_location"] = "If not default, use following wiki page as toolbox location:";
+$lang["vector_toolbox"]          = "Show tools?";
+$lang["vector_toolbox_default"]  = "If yes, use default tools?";
+$lang["vector_toolbox_location"] = "If not default, use following wiki page as tools location:";
 
 //qr code box
 $lang["vector_qrcodebox"] = "Show box with QR Code of current wiki page URL (for easy URL transfer to mobile browser)?";

--- a/lang/fr/lang.php
+++ b/lang/fr/lang.php
@@ -49,7 +49,7 @@ $lang["vector_translations"] = "Langages";
 
 //headlines for the different bars and boxes
 $lang["vector_navigation"] = "Navigation";
-$lang["vector_toolbox"] = "Boite à outils";
+$lang["vector_toolbox"] = "Outils";
 $lang["vector_exportbox"] = "Imprimer/exporter";
 $lang["vector_inotherlanguages"] = "Langages";
 $lang["vector_printexport"] = "Imprimer/exporter";

--- a/lang/fr/settings.php
+++ b/lang/fr/settings.php
@@ -54,8 +54,8 @@ $lang["vector_exportbox_default"]  = "Si oui, utilisez la boite 'imprimer/export
 $lang["vector_exportbox_location"] = "Si non, utilisez la page wiki suivante :";
 
 //toolbox
-$lang["vector_toolbox"]          = "Afficher la boite à outils ?";
-$lang["vector_toolbox_default"]  = "Si oui, utilisez la boite à outils par default ?";
+$lang["vector_toolbox"]          = "Afficher la outils ?";
+$lang["vector_toolbox_default"]  = "Si oui, utilisez la outils par default ?";
 $lang["vector_toolbox_location"] = "Si non, utilisez la page wiki suivante :";
 
 //custom copyright notice

--- a/lang/ko/lang.php
+++ b/lang/ko/lang.php
@@ -50,7 +50,7 @@ $lang["vector_translations"] = "언어";
 
 //headlines for the different bars and boxes
 $lang["vector_navigation"] = "둘러보기";
-$lang["vector_toolbox"] = "도구모음";
+$lang["vector_toolbox"] = "도구";
 $lang["vector_exportbox"] = "인쇄/내보내기";
 $lang["vector_qrcodebox"] = "QR 코드";
 $lang["vector_inotherlanguages"] = "언어";
@@ -59,11 +59,11 @@ $lang["vector_personnaltools"] = "개인 도구";
 
 //buttons
 $lang["vector_btn_go"] = "보기";
-$lang["vector_btn_search"] = "찾기";
-$lang["vector_btn_search_title"] = "이 문자열이 포함된 문서 찾기";
+$lang["vector_btn_search"] = "검색";
+$lang["vector_btn_search_title"] = "이 문자열이 포함된 문서 검색";
 
 //exportbox ("print/export")
-$lang["vector_exportbxdef_print"] = "인쇄용 문서";
+$lang["vector_exportbxdef_print"] = "인쇄용 판";
 $lang["vector_exportbxdef_downloadodt"] = "ODT로 다운로드";
 $lang["vector_exportbxdef_downloadpdf"] = "PDF로 다운로드";
 
@@ -104,7 +104,7 @@ $lang["vector_cite_result"] = "결과";
 $lang["vector_cite_thisversion"] = "이 판";
 
 //other
-$lang["vector_search"] = "찾기";
+$lang["vector_search"] = "검색";
 $lang["vector_accessdenied"] = "접근 거부됨";
 $lang["vector_fillplaceholder"] = "이 자리를 채우거나 비활성화하세요";
 $lang["vector_donate"] = "기부";

--- a/lang/ko/settings.php
+++ b/lang/ko/settings.php
@@ -56,9 +56,9 @@ $lang["vector_exportbox_default"]  = "만약 보여준다면 기본 '인쇄/내�
 $lang["vector_exportbox_location"] = "기본 모음을 사용하지 않는다면 '인쇄/내보내기' 모음 위치로 다음 위키 문서 사용:";
 
 //toolbox
-$lang["vector_toolbox"]          = "도구모음을 보여줄까요?";
-$lang["vector_toolbox_default"]  = "만약 보여준다면 기본 도구모음을 사용하겠습니까?";
-$lang["vector_toolbox_location"] = "기본 모음을 사용하지 않는다면 도구모음 위치로 다음 위키 문서 사용:";
+$lang["vector_toolbox"]          = "도구를 보여줄까요?";
+$lang["vector_toolbox_default"]  = "만약 보여준다면 기본 도구를 사용하겠습니까?";
+$lang["vector_toolbox_location"] = "기본 모음을 사용하지 않는다면 도구 위치로 다음 위키 문서 사용:";
 
 //qr code box
 $lang["vector_qrcodebox"] = "(모바일 브라우저에 쉽게 URL 전송을 위해) 현재 위키 문서 URL의 QR 코드로 된 상자를 보여줄까요?";

--- a/lang/zh/lang.php
+++ b/lang/zh/lang.php
@@ -49,7 +49,7 @@ $lang["vector_translations"] = "语言";
 
 //headlines for the different bars and boxes
 $lang["vector_navigation"] = "导航";
-$lang["vector_toolbox"] = "工具箱";
+$lang["vector_toolbox"] = "工具";
 $lang["vector_exportbox"] = "打印/导出";
 $lang["vector_inotherlanguages"] = "语言";
 $lang["vector_printexport"] = "打印/导出";
@@ -68,7 +68,7 @@ $lang["vector_exportbxdef_downloadpdf"] = "做为PDF下载";
 //default toolbox
 $lang["vector_toolbxdef_whatlinkshere"] = "反向链接";
 $lang["vector_toolbxdef_upload"] = "上传文件";
-$lang["vector_toolbxdef_siteindex"] = "站点索引";
+$lang["vector_toolbxdef_siteindex"] = "网站地图";
 $lang["vector_toolboxdef_permanent"] = "永久链接";
 $lang["vector_toolboxdef_cite"] = "引用此文";
 

--- a/lang/zh/settings.php
+++ b/lang/zh/settings.php
@@ -54,9 +54,9 @@ $lang["vector_exportbox_default"]  = "如果是，使用默认的“打印/导�
 $lang["vector_exportbox_location"] = "如果不是默认，使用下列wiki页面作为“打印/导出“栏位置：";
 
 //toolbox
-$lang["vector_toolbox"]          = "显示工具箱？";
-$lang["vector_toolbox_default"]  = "如果是，使用默认工具箱？";
-$lang["vector_toolbox_location"] = "如果不是默认，使用下列wiki页面作为工具箱位置：";
+$lang["vector_toolbox"]          = "显示工具？";
+$lang["vector_toolbox_default"]  = "如果是，使用默认工具？";
+$lang["vector_toolbox_location"] = "如果不是默认，使用下列wiki页面作为工具位置：";
 
 //custom copyright notice
 $lang["vector_copyright"]          = "显示版权信息？";


### PR DESCRIPTION
In MediaWiki, 'Toolbox' is renamed to 'Tools'. For more infomation, see page https://bugzilla.wikimedia.org/show_bug.cgi?id=54910 . And in DokuWiki, 'Index' is changed as 'Sitemap', so I change 'Site index' to 'Sitemap'.
