### PR TITLE
Fixed support for updated Translation plugin

### DIFF
--- a/conf/boxes.php
+++ b/conf/boxes.php
@@ -43,9 +43,9 @@ if (empty($conf["useacl"]) || //are there any users?
     //Languages/translations provided by Andreas Gohr's translation plugin,
     //see <https://www.dokuwiki.org/plugin:translation>. Create plugin object if
     //needed.
-    if (file_exists(DOKU_PLUGIN."translation/syntax.php") &&
+    if (file_exists(DOKU_PLUGIN."translation/helper.php") &&
         !plugin_isdisabled("translation")){
-        $transplugin = &plugin_load("syntax", "translation");
+        $transplugin = &plugin_load("helper", "translation");
     } else {
         $transplugin = false;
     }
@@ -60,7 +60,7 @@ if (empty($conf["useacl"]) || //are there any users?
             is_object($transplugin) &&
             tpl_getConf("vector_navigation_translate")){
             //translated navigation?
-            $transplugin_langcur = $transplugin->hlp->getLangPart(cleanID(getId())); //current language part
+            $transplugin_langcur = $transplugin->getLangPart(cleanID(getId())); //current language part
             $transplugin_langs   = explode(" ", trim($transplugin->getConf("translations"))); //available languages
             if (empty($transplugin_langs) ||
                 empty($transplugin_langcur) ||
@@ -248,7 +248,7 @@ if (empty($conf["useacl"]) || //are there any users?
 if (!empty($transplugin) &&
     is_object($transplugin)){
     $_vector_boxes["p-lang"]["headline"] = $lang["vector_translations"];
-    $_vector_boxes["p-lang"]["xhtml"]    = $transplugin->_showTranslations();
+    $_vector_boxes["p-lang"]["xhtml"]    = $transplugin->showTranslations();
 }
 
 

--- a/main.php
+++ b/main.php
@@ -527,7 +527,7 @@ if (file_exists(DOKU_TPLINC."lang/".$conf["lang"]."/style.css")){
           is_object($transplugin) &&
           tpl_getConf("vector_sitenotice_translate")){
           //translated site notice?
-          $transplugin_langcur = $transplugin->hlp->getLangPart(cleanID(getId())); //current language part
+          $transplugin_langcur = $transplugin->getLangPart(cleanID(getId())); //current language part
           $transplugin_langs   = explode(" ", trim($transplugin->getConf("translations"))); //available languages
           if (empty($transplugin_langs) ||
               empty($transplugin_langcur) ||
@@ -797,7 +797,7 @@ if (file_exists(DOKU_TPLINC."lang/".$conf["lang"]."/style.css")){
                 is_object($transplugin) &&
                 tpl_getConf("vector_copyright_translate")){
                 //translated copyright notice?
-                $transplugin_langcur = $transplugin->hlp->getLangPart(cleanID(getId())); //current language part
+                $transplugin_langcur = $transplugin->getLangPart(cleanID(getId())); //current language part
                 $transplugin_langs   = explode(" ", trim($transplugin->getConf("translations"))); //available languages
                 if (empty($transplugin_langs) ||
                     empty($transplugin_langcur) ||


### PR DESCRIPTION
Some code in the Translation plugin has changed some time ago, and now it needs to be loaded as a "helper" (instead of "syntax"). Two function calls to the new Translation code were changed also and are now fixed.
