### PR TITLE
Responsive Menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,0 +1,62 @@
+/**
+ * Copy all the navigational links into a single mobile menu
+ */
+jQuery(function () {
+    var $mobilemenu = jQuery('<div>')
+        .addClass('mobile-menu');
+
+
+    var $logo = jQuery('#p-logo')
+        .clone()
+        .removeAttr('id')
+        .addClass('mobile-logo')
+    ;
+
+    var $search = jQuery('#p-search form')
+        .clone()
+        .removeAttr('id')
+        .addClass('mobile-search');
+    $search.find('#simpleSearch').removeAttr('id');
+    $search.find('button').text('🔍');
+
+    $mobilemenu.append($search);
+
+    jQuery([
+        'p-navigation',
+        'left-navigation',
+        'right-navigation',
+        'p-coll-print_export',
+        'p-tb',
+        'p-personal'
+    ]).each(function (i, name) {
+        var ul = jQuery('<ul>');
+        $mobilemenu.append(ul);
+
+        var filter = '#' + name + ' li';
+        ul.addClass('mobile-' + name);
+        ul.append(
+            jQuery(filter)
+                .not('.selected')
+                .clone()
+                .removeAttr('id')
+        );
+    });
+
+    var $hamburger = jQuery('<div>')
+        .addClass('mobile-hamburger')
+        .click(function () {
+            $mobilemenu.toggleClass('open');
+            $hamburger.toggleClass('open')
+        });
+
+
+    jQuery('body')
+        .append([
+            $mobilemenu,
+            $hamburger
+        ])
+        .prepend(
+            $logo
+        )
+    ;
+});

--- a/static/mobile.less
+++ b/static/mobile.less
@@ -1,0 +1,106 @@
+div.mobile-hamburger,
+div.mobile-menu,
+div.mobile-logo {
+    display: none;
+}
+
+
+@media only screen and (max-width: 750px) {
+
+    div.mobile-hamburger {
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 1000;
+
+        cursor: pointer;
+        font-size: 2.5rem;
+        line-height: 3rem;
+
+        width: 3rem;
+        height: 3rem;
+        text-align: center;
+
+        &::before {
+            content: '☰';
+        }
+    }
+
+    div.mobile-hamburger.open {
+        &::before {
+            content: '✕';
+        }
+    }
+
+    div.mobile-logo {
+        display: block;
+        a {
+            display: block;
+            width: 100%;
+            height: 3rem;
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
+        }
+    }
+
+    div.mobile-menu {
+        position: absolute;
+        top: 0;
+        left: 0;
+
+        height: 100%;
+        overflow-y: auto;
+
+        z-index: 500;
+        background-color: @ini_background;
+        box-shadow: 5px 0 5px @ini_border;
+
+        padding-top: 3rem;
+
+        a {
+            color: @ini_existing;
+        }
+
+        .mobile-search {
+            display: block;
+            margin: 0.25em;
+            input,
+            button {
+                line-height: inherit;
+            }
+        }
+
+        ul {
+            padding: 0;
+            list-style-type: none;
+            list-style-image: none !important;
+            margin: 0.25em 0;
+
+            border-bottom: 1px solid @ini_border;
+
+            li {
+                margin: 0;
+                padding: 0.25em;
+            }
+        }
+    }
+
+    div.mobile-menu.open {
+        display: block;
+    }
+
+    #page-base,
+    #head-base,
+    #head,
+    #panel {
+        display: none;
+    }
+
+    div#content,
+    div#footer {
+        margin-left: 0;
+    }
+
+}

--- a/static/mobile.less
+++ b/static/mobile.less
@@ -28,6 +28,7 @@ div.mobile-logo {
     }
 
     div.mobile-hamburger.open {
+        background-color: @ini_background;
         &::before {
             content: '✕';
         }

--- a/static/mobile.less
+++ b/static/mobile.less
@@ -105,3 +105,11 @@ div.mobile-logo {
     }
 
 }
+
+// translation plugin adjustment
+div#panel .body .dokuwiki .plugin_translation ul li a.wikilink1:before,
+div#panel .body .dokuwiki .plugin_translation ul li a.wikilink2:before,
+div#panel .body .dokuwiki .plugin_translation ul li a.wikilink1:after,
+div#panel .body .dokuwiki .plugin_translation ul li a.wikilink2:after {
+    content: '';
+}

--- a/static/mobile.less
+++ b/static/mobile.less
@@ -11,7 +11,7 @@ div.mobile-logo {
         display: block;
         position: absolute;
         top: 0;
-        left: 0;
+        right: 0;
         z-index: 1000;
 
         cursor: pointer;
@@ -42,21 +42,26 @@ div.mobile-logo {
             height: 3rem;
             background-size: contain;
             background-repeat: no-repeat;
-            background-position: center;
+            background-position: left;
         }
     }
 
     div.mobile-menu {
         position: absolute;
         top: 0;
-        left: 0;
+        right: 0;
 
         height: 100%;
         overflow-y: auto;
+        -ms-overflow-style: none;  // IE 10+
+        overflow: -moz-scrollbars-none;  // Firefox
+        &::-webkit-scrollbar {
+            display: none;  // Safari and Chrome
+        }
 
         z-index: 500;
         background-color: @ini_background;
-        box-shadow: 5px 0 5px @ini_border;
+        box-shadow: -5px 0 5px @ini_border;
 
         padding-top: 3rem;
 
@@ -67,9 +72,17 @@ div.mobile-logo {
         .mobile-search {
             display: block;
             margin: 0.25em;
-            input,
-            button {
-                line-height: inherit;
+            div {
+                display: flex;
+
+                input,
+                button {
+                    line-height: inherit;
+                    flex-grow: 0;
+                }
+                input {
+                    flex-grow: 1;
+                }
             }
         }
 

--- a/style.ini
+++ b/style.ini
@@ -76,6 +76,8 @@ user/rtl.css       = rtl
 
 
 
+static/mobile.less = all
+
 
 ; This section is used to configure some placeholder values used in
 ; the stylesheets. Changing this file is the simplest method to


### PR DESCRIPTION
This PR uses some JavaScript to make the template more more usable on mobile devices. This may not be the most versatile approach but was the easiest way to implement it without having to change any of the original layout and corresponding CSS.

On small screens (breakpoint is 750px) all navigational menus will be hidden and a "hamburger menu" is used instead.

![download 1](https://user-images.githubusercontent.com/86426/40662089-a7cce652-6355-11e8-8fec-a21e333e792d.png)

One limitations is that only list items and the search form are copied to the menu - when you have other markup in the menus it will no longer show up in the hamburger menu.

I realize that this beyond the scope of a 1:1 mediawiki vector copy but it might still be useful to other users of the template.

