### PR TITLE
Fixed support for updated Bookcreator plugin

### DIFF
--- a/main.php
+++ b/main.php
@@ -512,7 +512,7 @@ if (file_exists(DOKU_TPLINC."lang/".$conf["lang"]."/style.css")){
 <div id="head-base" class="noprint"></div>
 
 <!-- start div id=content -->
-<div id="content">
+<div id="dokuwiki__content">
   <a name="top" id="top"></a>
   <a name="dokuwiki__top" id="dokuwiki__top"></a>
 

--- a/static/3rd/vector/main-ltr.css
+++ b/static/3rd/vector/main-ltr.css
@@ -33,7 +33,7 @@ body {
 	background-image: url(static/3rd/vector/page-base.png);
 }
 /* Content */
-div#content {
+div#dokuwiki__content {
 	margin-left: 10em;
 	padding: 1em;
 	background-image: url(static/3rd/vector/border.png);
@@ -619,7 +619,7 @@ div#footer #footer-places li {
  * The following code is slightly modified from monobook
  *
  */
-div#content {
+div#dokuwiki__content {
 	line-height: 1.5em;
 }
 #bodyContent {
@@ -954,7 +954,7 @@ img.thumbborder {
 #jump-to-nav {
 	display: none;
 }
-#contentSub, #contentSub2 {
+#dokuwiki__contentSub, #dokuwiki__contentSub2 {
 	font-size: 84%;
 	line-height: 1.2em;
 	margin: 0 0 1.4em 1em;
@@ -996,72 +996,72 @@ h3, h4, h5 {
 	font-size: 1.6em;
 	padding-bottom: 0;
 }
-div#content a.external,
-div#content a[href ^="gopher://"] {
+div#dokuwiki__content a.external,
+div#dokuwiki__content a[href ^="gopher://"] {
 	background: url(static/3rd/vector/external-link-ltr-icon.png) center right no-repeat;
 	padding: 0 13px 0 0;
 }
-div#content a[href ^="https://"],
+div#dokuwiki__content a[href ^="https://"],
 .link-https {
 	background: url(static/3rd/vector/lock-icon.png) center right no-repeat;
 	padding: 0 13px 0 0;
 }
-div#content a[href ^="mailto:"],
+div#dokuwiki__content a[href ^="mailto:"],
 .link-mailto {
 	background: url(static/3rd/vector/mail-icon.png) center right no-repeat;
 	padding: 0 13px 0 0;
 }
-div#content a[href ^="news://"] {
+div#dokuwiki__content a[href ^="news://"] {
 	background: url(static/3rd/vector/news-icon.png) center right no-repeat;
 	padding: 0 13px 0 0;
 }
-div#content a[href ^="ftp://"],
+div#dokuwiki__content a[href ^="ftp://"],
 .link-ftp {
 	background: url(static/3rd/vector/file-icon.png) center right no-repeat;
 	padding: 0 13px 0 0;
 }
-div#content a[href ^="irc://"],
-div#content a.extiw[href ^="irc://"],
+div#dokuwiki__content a[href ^="irc://"],
+div#dokuwiki__content a.extiw[href ^="irc://"],
 .link-irc {
 	background: url(static/3rd/vector/talk-icon.png) center right no-repeat;
 	padding: 0 13px 0 0;
 }
-div#content a.external[href $=".ogg"], div#content a.external[href $=".OGG"],
-div#content a.external[href $=".mid"], div#content a.external[href $=".MID"],
-div#content a.external[href $=".midi"], div#content a.external[href $=".MIDI"],
-div#content a.external[href $=".mp3"], div#content a.external[href $=".MP3"],
-div#content a.external[href $=".wav"], div#content a.external[href $=".WAV"],
-div#content a.external[href $=".wma"], div#content a.external[href $=".WMA"],
+div#dokuwiki__content a.external[href $=".ogg"], div#dokuwiki__content a.external[href $=".OGG"],
+div#dokuwiki__content a.external[href $=".mid"], div#dokuwiki__content a.external[href $=".MID"],
+div#dokuwiki__content a.external[href $=".midi"], div#dokuwiki__content a.external[href $=".MIDI"],
+div#dokuwiki__content a.external[href $=".mp3"], div#dokuwiki__content a.external[href $=".MP3"],
+div#dokuwiki__content a.external[href $=".wav"], div#dokuwiki__content a.external[href $=".WAV"],
+div#dokuwiki__content a.external[href $=".wma"], div#dokuwiki__content a.external[href $=".WMA"],
 .link-audio {
 	background: url("images/audio-icon.png") center right no-repeat;
 	padding: 0 13px 0 0;
 }
-div#content a.external[href $=".ogm"], div#content a.external[href $=".OGM"],
-div#content a.external[href $=".avi"], div#content a.external[href $=".AVI"],
-div#content a.external[href $=".mpeg"], div#content a.external[href $=".MPEG"],
-div#content a.external[href $=".mpg"], div#content a.external[href $=".MPG"],
+div#dokuwiki__content a.external[href $=".ogm"], div#dokuwiki__content a.external[href $=".OGM"],
+div#dokuwiki__content a.external[href $=".avi"], div#dokuwiki__content a.external[href $=".AVI"],
+div#dokuwiki__content a.external[href $=".mpeg"], div#dokuwiki__content a.external[href $=".MPEG"],
+div#dokuwiki__content a.external[href $=".mpg"], div#dokuwiki__content a.external[href $=".MPG"],
 .link-video {
 	background: url("images/video-icon.png") center right no-repeat;
 	padding: 0 13px 0 0;
 }
-div#content a.external[href $=".pdf"], div#content a.external[href $=".PDF"],
-div#content a.external[href *=".pdf#"], div#content a.external[href *=".PDF#"],
-div#content a.external[href *=".pdf?"], div#content a.external[href *=".PDF?"],
+div#dokuwiki__content a.external[href $=".pdf"], div#dokuwiki__content a.external[href $=".PDF"],
+div#dokuwiki__content a.external[href *=".pdf#"], div#dokuwiki__content a.external[href *=".PDF#"],
+div#dokuwiki__content a.external[href *=".pdf?"], div#dokuwiki__content a.external[href *=".PDF?"],
 .link-document {
 	background: url("images/document-icon.png") center right no-repeat;
 	padding: 0 13px 0 0;
 }
 /* Interwiki Styling  (Disabled) */
-div#content a.extiw,
-div#content a.extiw:active {
+div#dokuwiki__content a.extiw,
+div#dokuwiki__content a.extiw:active {
 	color: #36b;
 	background: none;
 	padding: 0;
 }
-div#content a.external {
+div#dokuwiki__content a.external {
 	color: #36b;
 }
-div#content .printfooter {
+div#dokuwiki__content .printfooter {
 	display: none;
 }
 /* Icon for Usernames */

--- a/static/3rd/vector/main-rtl.css
+++ b/static/3rd/vector/main-rtl.css
@@ -33,7 +33,7 @@ body {
 	background-image: url(static/3rd/vector/page-base.png);
 }
 /* Content */
-div#content {
+div#dokuwiki__content {
 	margin-right: 10em;
 	padding: 1em;
 	background-image: url(static/3rd/vector/border.png);
@@ -619,7 +619,7 @@ div#footer #footer-places li {
  * The following code is slightly modified from monobook
  *
  */
-div#content {
+div#dokuwiki__content {
 	line-height: 1.5em;
 }
 #bodyContent {
@@ -954,7 +954,7 @@ img.thumbborder {
 #jump-to-nav {
 	display: none;
 }
-#contentSub, #contentSub2 {
+#dokuwiki__contentSub, #dokuwiki__contentSub2 {
 	font-size: 84%;
 	line-height: 1.2em;
 	margin: 0 1em 1.4em 0;
@@ -996,72 +996,72 @@ h3, h4, h5 {
 	font-size: 1.6em;
 	padding-bottom: 0;
 }
-div#content a.external,
-div#content a[href ^="gopher://"] {
+div#dokuwiki__content a.external,
+div#dokuwiki__content a[href ^="gopher://"] {
 	background: url(static/3rd/vector/external-link-rtl-icon.png) center left no-repeat;
 	padding: 0 0 0 13px;
 }
-div#content a[href ^="https://"],
+div#dokuwiki__content a[href ^="https://"],
 .link-https {
 	background: url(static/3rd/vector/lock-icon.png) center left no-repeat;
 	padding: 0 0 0 13px;
 }
-div#content a[href ^="mailto:"],
+div#dokuwiki__content a[href ^="mailto:"],
 .link-mailto {
 	background: url(static/3rd/vector/mail-icon.png) center left no-repeat;
 	padding: 0 0 0 13px;
 }
-div#content a[href ^="news://"] {
+div#dokuwiki__content a[href ^="news://"] {
 	background: url(static/3rd/vector/news-icon.png) center left no-repeat;
 	padding: 0 0 0 13px;
 }
-div#content a[href ^="ftp://"],
+div#dokuwiki__content a[href ^="ftp://"],
 .link-ftp {
 	background: url(static/3rd/vector/file-icon.png) center left no-repeat;
 	padding: 0 0 0 13px;
 }
-div#content a[href ^="irc://"],
-div#content a.extiw[href ^="irc://"],
+div#dokuwiki__content a[href ^="irc://"],
+div#dokuwiki__content a.extiw[href ^="irc://"],
 .link-irc {
 	background: url(static/3rd/vector/talk-icon.png) center left no-repeat;
 	padding: 0 0 0 13px;
 }
-div#content a.external[href $=".ogg"], div#content a.external[href $=".OGG"],
-div#content a.external[href $=".mid"], div#content a.external[href $=".MID"],
-div#content a.external[href $=".midi"], div#content a.external[href $=".MIDI"],
-div#content a.external[href $=".mp3"], div#content a.external[href $=".MP3"],
-div#content a.external[href $=".wav"], div#content a.external[href $=".WAV"],
-div#content a.external[href $=".wma"], div#content a.external[href $=".WMA"],
+div#dokuwiki__content a.external[href $=".ogg"], div#dokuwiki__content a.external[href $=".OGG"],
+div#dokuwiki__content a.external[href $=".mid"], div#dokuwiki__content a.external[href $=".MID"],
+div#dokuwiki__content a.external[href $=".midi"], div#dokuwiki__content a.external[href $=".MIDI"],
+div#dokuwiki__content a.external[href $=".mp3"], div#dokuwiki__content a.external[href $=".MP3"],
+div#dokuwiki__content a.external[href $=".wav"], div#dokuwiki__content a.external[href $=".WAV"],
+div#dokuwiki__content a.external[href $=".wma"], div#dokuwiki__content a.external[href $=".WMA"],
 .link-audio {
 	background: url("images/audio-icon.png") center left no-repeat;
 	padding: 0 0 0 13px;
 }
-div#content a.external[href $=".ogm"], div#content a.external[href $=".OGM"],
-div#content a.external[href $=".avi"], div#content a.external[href $=".AVI"],
-div#content a.external[href $=".mpeg"], div#content a.external[href $=".MPEG"],
-div#content a.external[href $=".mpg"], div#content a.external[href $=".MPG"],
+div#dokuwiki__content a.external[href $=".ogm"], div#dokuwiki__content a.external[href $=".OGM"],
+div#dokuwiki__content a.external[href $=".avi"], div#dokuwiki__content a.external[href $=".AVI"],
+div#dokuwiki__content a.external[href $=".mpeg"], div#dokuwiki__content a.external[href $=".MPEG"],
+div#dokuwiki__content a.external[href $=".mpg"], div#dokuwiki__content a.external[href $=".MPG"],
 .link-video {
 	background: url("images/video-icon.png") center left no-repeat;
 	padding: 0 0 0 13px;
 }
-div#content a.external[href $=".pdf"], div#content a.external[href $=".PDF"],
-div#content a.external[href *=".pdf#"], div#content a.external[href *=".PDF#"],
-div#content a.external[href *=".pdf?"], div#content a.external[href *=".PDF?"],
+div#dokuwiki__content a.external[href $=".pdf"], div#dokuwiki__content a.external[href $=".PDF"],
+div#dokuwiki__content a.external[href *=".pdf#"], div#dokuwiki__content a.external[href *=".PDF#"],
+div#dokuwiki__content a.external[href *=".pdf?"], div#dokuwiki__content a.external[href *=".PDF?"],
 .link-document {
 	background: url("images/document-icon.png") center left no-repeat;
 	padding: 0 0 0 13px;
 }
 /* Interwiki Styling  (Disabled) */
-div#content a.extiw,
-div#content a.extiw:active {
+div#dokuwiki__content a.extiw,
+div#dokuwiki__content a.extiw:active {
 	color: #36b;
 	background: none;
 	padding: 0;
 }
-div#content a.external {
+div#dokuwiki__content a.external {
 	color: #36b;
 }
-div#content .printfooter {
+div#dokuwiki__content .printfooter {
 	display: none;
 }
 /* Icon for Usernames */

--- a/static/css/print.css
+++ b/static/css/print.css
@@ -9,28 +9,28 @@
 body {
   font: normal 80%/1.4 sans-serif;
 }
-div#content .dokuwiki h1,
-div#content .dokuwiki h2,
-div#content .dokuwiki h3,
-div#content .dokuwiki h4,
-div#content .dokuwiki h5,
-div#content .dokuwiki h6 {
+div#dokuwiki__content .dokuwiki h1,
+div#dokuwiki__content .dokuwiki h2,
+div#dokuwiki__content .dokuwiki h3,
+div#dokuwiki__content .dokuwiki h4,
+div#dokuwiki__content .dokuwiki h5,
+div#dokuwiki__content .dokuwiki h6 {
   border-bottom: 0 none;
 }
-div#content .dokuwiki h1,
-div#content .dokuwiki h2 {
+div#dokuwiki__content .dokuwiki h1,
+div#dokuwiki__content .dokuwiki h2 {
   font-weight: bold;
 }
-div#content .dokuwiki h1 {
+div#dokuwiki__content .dokuwiki h1 {
   font-weight: 135%;
 }
-div#content .dokuwiki h2 {
+div#dokuwiki__content .dokuwiki h2 {
   font-weight: 130%;
 }
-div#content .dokuwiki h3,
-div#content .dokuwiki h4,
-div#content .dokuwiki h5,
-div#content .dokuwiki h6 {
+div#dokuwiki__content .dokuwiki h3,
+div#dokuwiki__content .dokuwiki h4,
+div#dokuwiki__content .dokuwiki h5,
+div#dokuwiki__content .dokuwiki h6 {
   font-weight: normal;
   text-decoration: underline;
 }
@@ -52,36 +52,36 @@ div.dokuwiki a.interwiki {
 }
 
 /* quotes */
-div#content .dokuwiki blockquote {
+div#dokuwiki__content .dokuwiki blockquote {
   border-left: 2px solid __border__;
   padding-left: 3px;
   margin-left: 0.2em;
 }
 
 /* preformatted stuff, source code */
-div#content .dokuwiki code,
-div#content .dokuwiki pre,
-div#content .dokuwiki pre.code,
-div#content .dokuwiki pre.file {
+div#dokuwiki__content .dokuwiki code,
+div#dokuwiki__content .dokuwiki pre,
+div#dokuwiki__content .dokuwiki pre.code,
+div#dokuwiki__content .dokuwiki pre.file {
   font-size: 100%;
 }
-div#content .dokuwiki pre,
-div#content .dokuwiki pre.code,
-div#content .dokuwiki pre.file {
+div#dokuwiki__content .dokuwiki pre,
+div#dokuwiki__content .dokuwiki pre.code,
+div#dokuwiki__content .dokuwiki pre.file {
   line-height: 1.2em;
   background-color: __background_other__;
 }
-div#content .dokuwiki dl.file,
-div#content .dokuwiki dl.file dd,
-div#content .dokuwiki dl.file dt {
+div#dokuwiki__content .dokuwiki dl.file,
+div#dokuwiki__content .dokuwiki dl.file dd,
+div#dokuwiki__content .dokuwiki dl.file dt {
   margin-left: 0;
 }
-div#content .dokuwiki dl.file dt {
+div#dokuwiki__content .dokuwiki dl.file dt {
   background-color: __background_other__;
 }
 
 /* misc tweaks */
-div#content,
+div#dokuwiki__content,
 div#bodyContent {
   margin-left: 0;
   border: 0 none;
@@ -98,18 +98,18 @@ div.tags {
 }
 
 /* pagelist plugin: listing tables */
-div#content .dokuwiki table.ul,
-div#content .dokuwiki table.ul tr,
-div#content .dokuwiki table.ul td {
+div#dokuwiki__content .dokuwiki table.ul,
+div#dokuwiki__content .dokuwiki table.ul tr,
+div#dokuwiki__content .dokuwiki table.ul td {
   border: 0 none;
 }
-div#content .dokuwiki table.ul td.date,
-div#content .dokuwiki table.ul td.user {
+div#dokuwiki__content .dokuwiki table.ul td.date,
+div#dokuwiki__content .dokuwiki table.ul td.user {
   display: none;
 }
-div#content .dokuwiki table.ul ul,
-div#content .dokuwiki table.ul ol,
-div#content .dokuwiki table.ul li {
+div#dokuwiki__content .dokuwiki table.ul ul,
+div#dokuwiki__content .dokuwiki table.ul ol,
+div#dokuwiki__content .dokuwiki table.ul li {
   margin-top: 0;
   margin-bottom: 0;
   padding-top: 0;
@@ -117,19 +117,19 @@ div#content .dokuwiki table.ul li {
 }
 
 /* wrap plugin: modify some inline styles */
-div#content .dokuwiki span.wrap_box,
-div#content .dokuwiki span.wrap_danger,
-div#content .dokuwiki span.wrap_warning,
-div#content .dokuwiki span.wrap_caution,
-div#content .dokuwiki span.wrap_notice,
-div#content .dokuwiki span.wrap_safety,
-div#content .dokuwiki span.wrap_info,
-div#content .dokuwiki span.wrap_important,
-div#content .dokuwiki span.wrap_alert,
-div#content .dokuwiki span.wrap_tip,
-div#content .dokuwiki span.wrap_help,
-div#content .dokuwiki span.wrap_todo,
-div#content .dokuwiki span.wrap_download {
+div#dokuwiki__content .dokuwiki span.wrap_box,
+div#dokuwiki__content .dokuwiki span.wrap_danger,
+div#dokuwiki__content .dokuwiki span.wrap_warning,
+div#dokuwiki__content .dokuwiki span.wrap_caution,
+div#dokuwiki__content .dokuwiki span.wrap_notice,
+div#dokuwiki__content .dokuwiki span.wrap_safety,
+div#dokuwiki__content .dokuwiki span.wrap_info,
+div#dokuwiki__content .dokuwiki span.wrap_important,
+div#dokuwiki__content .dokuwiki span.wrap_alert,
+div#dokuwiki__content .dokuwiki span.wrap_tip,
+div#dokuwiki__content .dokuwiki span.wrap_help,
+div#dokuwiki__content .dokuwiki span.wrap_todo,
+div#dokuwiki__content .dokuwiki span.wrap_download {
   border-top: 0 none;
   border-right: 0 none;
   border-left: 0 none;

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -480,69 +480,69 @@ h6 {
   padding: 0;
   clear: left; /* ideally 'both', but problems with toc */
 }
-div#content .dokuwiki h1,
-div#content .dokuwiki h2,
-div#content .dokuwiki h3,
-div#content .dokuwiki h4,
-div#content .dokuwiki h5,
-div#content .dokuwiki h6 {
+div#dokuwiki__content .dokuwiki h1,
+div#dokuwiki__content .dokuwiki h2,
+div#dokuwiki__content .dokuwiki h3,
+div#dokuwiki__content .dokuwiki h4,
+div#dokuwiki__content .dokuwiki h5,
+div#dokuwiki__content .dokuwiki h6 {
   border-bottom: 1px solid #aaa;
   color: __text__;
   margin: 0;
   padding-bottom: 0.17em;
   padding-top: 0.5em;
 }
-div#content .dokuwiki h1 a,
-div#content .dokuwiki h2 a,
-div#content .dokuwiki h3 a,
-div#content .dokuwiki h4 a,
-div#content .dokuwiki h5 a,
-div#content .dokuwiki h6 a {
+div#dokuwiki__content .dokuwiki h1 a,
+div#dokuwiki__content .dokuwiki h2 a,
+div#dokuwiki__content .dokuwiki h3 a,
+div#dokuwiki__content .dokuwiki h4 a,
+div#dokuwiki__content .dokuwiki h5 a,
+div#dokuwiki__content .dokuwiki h6 a {
   color: __text__;
 }
-div#content .dokuwiki h1 a:hover,
-div#content .dokuwiki h2 a:hover,
-div#content .dokuwiki h3 a:hover,
-div#content .dokuwiki h4 a:hover,
-div#content .dokuwiki h5 a:hover,
-div#content .dokuwiki h6 a:hover {
+div#dokuwiki__content .dokuwiki h1 a:hover,
+div#dokuwiki__content .dokuwiki h2 a:hover,
+div#dokuwiki__content .dokuwiki h3 a:hover,
+div#dokuwiki__content .dokuwiki h4 a:hover,
+div#dokuwiki__content .dokuwiki h5 a:hover,
+div#dokuwiki__content .dokuwiki h6 a:hover {
   text-decoration: none;
 }
-div#content .dokuwiki h1 {
+div#dokuwiki__content .dokuwiki h1 {
   font-size: 160%;
 }
-div#content .dokuwiki h1,
-div#content .dokuwiki h2 {
+div#dokuwiki__content .dokuwiki h1,
+div#dokuwiki__content .dokuwiki h2 {
   margin-bottom: 0.6em;
   font-weight: normal;
 }
-div#content .dokuwiki h3,
-div#content .dokuwiki h4,
-div#content .dokuwiki h5,
-div#content .dokuwiki h6 {
+div#dokuwiki__content .dokuwiki h3,
+div#dokuwiki__content .dokuwiki h4,
+div#dokuwiki__content .dokuwiki h5,
+div#dokuwiki__content .dokuwiki h6 {
   font-weight: bold;
   border-bottom: none;
   margin-bottom: 0.3em;
 }
-div#content .dokuwiki h3 {
+div#dokuwiki__content .dokuwiki h3 {
   font-size: 132%;
 }
-div#content .dokuwiki h4 {
+div#dokuwiki__content .dokuwiki h4 {
   font-size: 116%;
 }
-div#content .dokuwiki h5 {
+div#dokuwiki__content .dokuwiki h5 {
   font-size: 100%;
 }
-div#content .dokuwiki h6 {
+div#dokuwiki__content .dokuwiki h6 {
   font-size: 80%;
 }
 
 /* remove indent from different sections */
-div#content .dokuwiki div.level1,
-div#content .dokuwiki div.level2,
-div#content .dokuwiki div.level3,
-div#content .dokuwiki div.level4,
-div#content .dokuwiki div.level5 {
+div#dokuwiki__content .dokuwiki div.level1,
+div#dokuwiki__content .dokuwiki div.level2,
+div#dokuwiki__content .dokuwiki div.level3,
+div#dokuwiki__content .dokuwiki div.level4,
+div#dokuwiki__content .dokuwiki div.level5 {
   margin-left: 0;
 }
 
@@ -594,7 +594,7 @@ div.dokuwiki li {
 }
 
 /* quotes */
-div#content .dokuwiki blockquote {
+div#dokuwiki__content .dokuwiki blockquote {
   border-left: 2px solid __border__;
   padding-left: 3px;
   padding-right: 0;
@@ -616,13 +616,13 @@ div#content .dokuwiki blockquote {
 .dokuwiki dl.file dd {
   margin: 0;
 }
-div#content .dokuwiki code,
-div#content .dokuwiki pre,
-div#content .dokuwiki pre.code,
-div#content .dokuwiki pre.file,
-div#content .dokuwiki samp,
-div#content .dokuwiki kbd,
-div#content .dokuwiki tt {
+div#dokuwiki__content .dokuwiki code,
+div#dokuwiki__content .dokuwiki pre,
+div#dokuwiki__content .dokuwiki pre.code,
+div#dokuwiki__content .dokuwiki pre.file,
+div#dokuwiki__content .dokuwiki samp,
+div#dokuwiki__content .dokuwiki kbd,
+div#dokuwiki__content .dokuwiki tt {
   font-size: 100%;
   background-color: #f9f9f9;
   color: __text__;
@@ -630,22 +630,22 @@ div#content .dokuwiki tt {
   direction: ltr;
   text-align: left;
 }
-div#content .dokuwiki em.u code { /* fix if background-color hides underlining */
+div#dokuwiki__content .dokuwiki em.u code { /* fix if background-color hides underlining */
   text-decoration: underline;
 }
-div#content .dokuwiki pre,
-div#content .dokuwiki pre.code,
-div#content .dokuwiki pre.file {
+div#dokuwiki__content .dokuwiki pre,
+div#dokuwiki__content .dokuwiki pre.code,
+div#dokuwiki__content .dokuwiki pre.file {
   line-height: 1.2em;
   padding: 0.5em;
   border: 1px dashed __border__;
 }
-div#content .dokuwiki dl.file,
-div#content .dokuwiki dl.file dd {
+div#dokuwiki__content .dokuwiki dl.file,
+div#dokuwiki__content .dokuwiki dl.file dd {
   margin-left: 0;
 }
-div#content .dokuwiki dl.file dt,
-div#content .dokuwiki dl.code dt {
+div#dokuwiki__content .dokuwiki dl.file dt,
+div#dokuwiki__content .dokuwiki dl.code dt {
   background-color: #f9f9f9;
   border-bottom: 2px solid #f9f9f9;
   border-top: 1px dashed __border__;
@@ -655,8 +655,8 @@ div#content .dokuwiki dl.code dt {
   margin-left: 2em;
   padding: 0.1em 1em;
 }
-div#content .dokuwiki dl.file dt a,
-div#content .dokuwiki dl.code dt a {
+div#dokuwiki__content .dokuwiki dl.file dt a,
+div#dokuwiki__content .dokuwiki dl.code dt a {
   color: __text__;
 }
 
@@ -700,7 +700,7 @@ th[align="right"] {
 .dokuwiki .secedit {
   margin-top: 0;
 }
-div#content .dokuwiki div.secedit input.button {
+div#dokuwiki__content .dokuwiki div.secedit input.button {
   border: 0 none;
   text-transform: lowercase;
   color: __existing__;
@@ -1132,7 +1132,7 @@ div.notify {
 
 /* --------------- admin menu --------------- */
 /* editing preview */
-div#content .dokuwiki div.preview {
+div#dokuwiki__content .dokuwiki div.preview {
   margin-left: 0;
 }
 /* "remeber me" checkbox, login */


### PR DESCRIPTION
Items added to the book aren't shown because Bookcreator expects that the content of the page is located into #dokuwiki__content instead of #content HTML tag. This fix updates CSS files and the main.php file to reflect these changes and make the plug-in work as expected.