### PR TITLE
Sidebar isn't shown for non-admin users

### DIFF
--- a/conf/boxes.php
+++ b/conf/boxes.php
@@ -81,7 +81,7 @@ if (empty($conf["useacl"]) || //are there any users?
         if (empty($conf["useacl"]) ||
             auth_quickaclcheck(cleanID($nav_location)) >= AUTH_READ){ //current user got access?
             //get the rendered content of the defined wiki article to use as custom navigation
-            $interim = tpl_include_page($nav_location, false);
+            $interim = tpl_include_page($nav_location, false, false, false);
             if ($interim === "" ||
                 $interim === false){
                 //creation/edit link if the defined page got no content


### PR DESCRIPTION
Fixes https://forum.dokuwiki.org/d/15407-wiki-navigation-acl-broken
Disabling ACL check isn't a security issue because ACL are checked before printing the sidebar contents.